### PR TITLE
switch back to position: fixed

### DIFF
--- a/src/fallback-fullscreen.js
+++ b/src/fallback-fullscreen.js
@@ -2,7 +2,7 @@ var FullScreenFallback = function() {
 	FullScreenFallback._super.constructor.apply(this, arguments);
 	this._DEFAULT_OPTIONS = $.extend({}, this._DEFAULT_OPTIONS, {
 		'styles': {
-			'position': 'absolute',
+			'position': 'fixed',
 			'zIndex': '2147483647',
 			'left': 0,
 			'top': 0,


### PR DESCRIPTION
otherwise the fallback won't work on pages larger than the viewport of the device
fixes #31 